### PR TITLE
Fix deprecation docs on 'int' and 'num'

### DIFF
--- a/src/React/Basic/Emotion.purs
+++ b/src/React/Basic/Emotion.purs
@@ -132,13 +132,13 @@ str :: String -> StyleProperty
 str = unsafeCoerce
 
 int
-  :: Warn (Text "`int` is deprecated and may be removed in future versions. Prefer one of the unit combinators like `px` or `em` instead.")
+  :: Warn (Text "`int` is deprecated and may be removed in future versions. Prefer `str` or one of the unit combinators like `px` or `em` instead.")
   => Int
   -> StyleProperty
 int = unsafeCoerce
 
 num
-  :: Warn (Text "`int` is deprecated and may be removed in future versions. Prefer one of the unit combinators like `px` or `em` instead.")
+  :: Warn (Text "`int` is deprecated and may be removed in future versions. Prefer `str` or one of the unit combinators like `px` or `em` instead.")
   => Number
   -> StyleProperty
 num = unsafeCoerce


### PR DESCRIPTION
The `int` and `num` functions may also be replaced with `str` in some cases, like with `flex-shrink` or `flex-grow`.