### PR TITLE
Add keyframes

### DIFF
--- a/src/React/Basic/Emotion.js
+++ b/src/React/Basic/Emotion.js
@@ -36,3 +36,5 @@ exports.global = Emotion.Global;
 exports.css = _homogeneousDict => Emotion.css;
 
 exports.important = prop => typeof prop === "string" ? prop + " !important" : prop;
+
+exports.keyframes = _homogeneousDict => Emotion.keyframes;

--- a/src/React/Basic/Emotion.purs
+++ b/src/React/Basic/Emotion.purs
@@ -9,6 +9,7 @@ module React.Basic.Emotion
   , elementKeyed
   , css
   , important
+  , keyframes
   , nested
   , merge
   , str
@@ -133,6 +134,8 @@ foreign import global :: ReactComponent { styles :: Style }
 foreign import css :: forall r. Homogeneous r StyleProperty => { | r } -> Style
 
 foreign import important :: StyleProperty -> StyleProperty
+
+foreign import keyframes :: forall r. Homogeneous r StyleProperty => { | r } -> StyleProperty
 
 nested :: Style -> StyleProperty
 nested = unsafeCoerce

--- a/src/React/Basic/Emotion.purs
+++ b/src/React/Basic/Emotion.purs
@@ -8,6 +8,7 @@ module React.Basic.Emotion
   , element
   , elementKeyed
   , css
+  , global
   , important
   , keyframes
   , nested


### PR DESCRIPTION
This adds keyframes for animations. Example:

```purescript
rotatingKeyframes ∷ E.StyleProperty
rotatingKeyframes =
  E.keyframes
    { from: E.nested $ E.css { transform: E.str "rotate(0deg)"}
    , to: E.nested $ E.css { transform: E.str "rotate(360deg)"}

    }

containerStyle ∷ E.Style
containerStyle =
  E.css
    { width: E.str "100%"
    , height: E.str "100%"
    , animationName: rotatingKeyframes
    , animationDuration: E.str "2s"
    , animationIterationCount: E.str "infinite"
    }
```

Closes #7 