### PR TITLE
url double-quote argument

### DIFF
--- a/src/React/Basic/Emotion.purs
+++ b/src/React/Basic/Emotion.purs
@@ -208,7 +208,7 @@ fallbacks :: Array StyleProperty -> StyleProperty
 fallbacks = unsafeCoerce
 
 url :: URL -> StyleProperty
-url (URL url') = str ("url(" <> url' <> ")")
+url (URL url') = str ("url(\"" <> url' <> "\")")
 
 color :: Color -> StyleProperty
 color = str <<< cssStringHSLA


### PR DESCRIPTION
Double-quote the argument to a `url` property.

Resolves #14 